### PR TITLE
Add support for YouTubeTV

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CastTube
 
-casttube provides a way to interact with the Youtube Chromecast api.
+casttube provides a way to interact with the Youtube and Youtube TV Chromecast api.
 
 **Install:**
 
@@ -16,6 +16,7 @@ pip install casttube
 * Remove video
 * Clear the entire queue
 
+Example usage:
 ```
 from casttube import YouTubeSession
 session = YouTubeSession(screen_id)
@@ -24,10 +25,35 @@ session = YouTubeSession(screen_id)
 session.play_video(video_id)
 ```
 
+or for Youtube TV
+
+```
+from casttube import YouTubeTVSession
+# Add the required Authentication Cookies. These can be found by browsing to YouTube TV,
+# logging in, opening the element inspector and browsing to
+# Application > Storage > Cookies > https://tv.youtube.com
+# and filling in the matching cookie values below.
+cookies = {
+    "APISID": "",
+    "HSID": "",
+    "SAPISID": "",
+    "SID": "",
+    "SSID": "",
+}
+session = YouTubeTVSession(screen_id, cookies)
+
+# YouTube TV video id is https://tv.youtube.com/watch/video_id
+session.play_video(video_id)
+```
+
 The library requires 2 things:
 1. screen id
-2. The Chromecast youtube app needs to be open
+2. The Chromecast Youtube or Youtube TV app needs to be open
 
 There is a small script in https://github.com/ur1katz/CastTube-Scripts to print the screen id and launch the app.
 
+**Youtube TV:**
 
+The Youtube TV Casting API is extremely similar to the Youtube one. The only major difference is Youtube TV requires authentication cookies to be passed in as part of your session, which means a Youtube TV subscription is required.
+
+The channels for Youtube TV are different for each area so extracting them is left as an exercise for the implementer. It is very easy to get a list of channels, just go to the `Live` tab in YouTube TV and click on a currently playing show. You will then get a URL that is extremely similar to a YouTube URL. Simply copy the video_id from there.

--- a/README.md
+++ b/README.md
@@ -25,22 +25,24 @@ session = YouTubeSession(screen_id)
 session.play_video(video_id)
 ```
 
-or for Youtube TV
+For Youtube TV you will need to first follow the instructions provided by [requests-oauthlib](https://requests-oauthlib.readthedocs.io/en/latest/examples/google.html) to create an `OAuth2Session` which is authorized for the following scope:
+
+```
+scope = [
+    "https://www.googleapis.com/auth/youtube"
+]
+```
+
+Once you have an authorized session you can interact with Youtube TV as follows:
 
 ```
 from casttube import YouTubeTVSession
-# Add the required Authentication Cookies. These can be found by browsing to YouTube TV,
-# logging in, opening the element inspector and browsing to
-# Application > Storage > Cookies > https://tv.youtube.com
-# and filling in the matching cookie values below.
-cookies = {
-    "APISID": "",
-    "HSID": "",
-    "SAPISID": "",
-    "SID": "",
-    "SSID": "",
-}
-session = YouTubeTVSession(screen_id, cookies)
+
+# Create request_handler here based on the instructions from request-oauthlib
+# For example: request_handler = OAuth2Session(...)
+
+# Pass the request handler to the Youtube TV Session initializer
+session = YouTubeTVSession(screen_id, request_handler)
 
 # YouTube TV video id is https://tv.youtube.com/watch/video_id
 session.play_video(video_id)
@@ -54,6 +56,6 @@ There is a small script in https://github.com/ur1katz/CastTube-Scripts to print 
 
 **Youtube TV:**
 
-The Youtube TV Casting API is extremely similar to the Youtube one. The only major difference is Youtube TV requires authentication cookies to be passed in as part of your session, which means a Youtube TV subscription is required.
+The Youtube TV Casting API is extremely similar to the Youtube one. The only major difference is Youtube TV requires authentication to be passed in as part of your session, which means a Youtube TV subscription is required.
 
 The channels for Youtube TV are different for each area so extracting them is left as an exercise for the implementer. It is very easy to get a list of channels, just go to the `Live` tab in YouTube TV and click on a currently playing show. You will then get a URL that is extremely similar to a YouTube URL. Simply copy the video_id from there.

--- a/casttube/YouTubeSession.py
+++ b/casttube/YouTubeSession.py
@@ -143,7 +143,7 @@ class YouTubeSession(object):
         request_data = self._format_session_params(request_data)
         url_params = {SID: self._sid, GSESSIONID: self._gsession_id,
                       RID: self._rid, VER: 8, CVER: 1}
-        res = self._do_post(BIND_URL, data=request_data, headers={LOUNGE_ID_HEADER: self._lounge_token},
+        self._do_post(BIND_URL, data=request_data, headers={LOUNGE_ID_HEADER: self._lounge_token},
                       session_request=True, params=url_params, cookies=self._cookies)
 
     def _queue_action(self, video_id, action):

--- a/casttube/YouTubeTVSession.py
+++ b/casttube/YouTubeTVSession.py
@@ -4,7 +4,7 @@ from .YouTubeSession import BIND_DATA
 
 YOUTUBE_BASE_URL = "https://tv.youtube.com/"
 
-BIND_DATA.update({"theme": "up"})
+BIND_DATA = {**BIND_DATA, **{"theme": "up"}}
 
 class YouTubeTVSession(YouTubeSession):
     """ The main logic to interact with YouTube cast api."""

--- a/casttube/YouTubeTVSession.py
+++ b/casttube/YouTubeTVSession.py
@@ -9,6 +9,6 @@ BIND_DATA = {**BIND_DATA, **{"theme": "up"}}
 class YouTubeTVSession(YouTubeSession):
     """ The main logic to interact with YouTube cast api."""
 
-    def __init__(self, screen_id, cookies=None):
-        super(YouTubeTVSession, self).__init__(screen_id, cookies)
+    def __init__(self, screen_id, request_handler):
+        super(YouTubeTVSession, self).__init__(screen_id, request_handler)
         self._bind_data = BIND_DATA

--- a/casttube/YouTubeTVSession.py
+++ b/casttube/YouTubeTVSession.py
@@ -1,9 +1,10 @@
 from . import YouTubeSession
 
+from .YouTubeSession import BIND_DATA
+
 YOUTUBE_BASE_URL = "https://tv.youtube.com/"
 
-BIND_DATA = {"device": "REMOTE_CONTROL", "id": "aaaaaaaaaaaaaaaaaaaaaaaaaa", "name": "Python",
-             "mdx-version": 3, "pairing_type": "cast", "app": "android-phone-13.14.55", "theme": "up"}
+BIND_DATA.update({"theme": "up"})
 
 class YouTubeTVSession(YouTubeSession):
     """ The main logic to interact with YouTube cast api."""

--- a/casttube/YouTubeTVSession.py
+++ b/casttube/YouTubeTVSession.py
@@ -1,0 +1,13 @@
+from . import YouTubeSession
+
+YOUTUBE_BASE_URL = "https://tv.youtube.com/"
+
+BIND_DATA = {"device": "REMOTE_CONTROL", "id": "aaaaaaaaaaaaaaaaaaaaaaaaaa", "name": "Python",
+             "mdx-version": 3, "pairing_type": "cast", "app": "android-phone-13.14.55", "theme": "up"}
+
+class YouTubeTVSession(YouTubeSession):
+    """ The main logic to interact with YouTube cast api."""
+
+    def __init__(self, screen_id, cookies=None):
+        super(YouTubeTVSession, self).__init__(screen_id, cookies)
+        self._bind_data = BIND_DATA

--- a/casttube/__init__.py
+++ b/casttube/__init__.py
@@ -1,3 +1,4 @@
 from .YouTubeSession import YouTubeSession
+from .YouTubeTVSession import YouTubeTVSession
 
 __version__ = '0.1.0'


### PR DESCRIPTION
Specifically, there are only 2 differences between you Youtube API and the YoutubeTV api. The Youtube TV API requires authentication while it is optional on Youtube, and the endpoint is different. This adds support for authentication and adds the proper bind_data for YoutubeTV.