### PR TITLE
Use a message log to avoid dropping messages

### DIFF
--- a/casttube/YouTubeSession.py
+++ b/casttube/YouTubeSession.py
@@ -212,8 +212,8 @@ class YouTubeSession(object):
         :return: queue playlist id or None
         """
         session_data = self.get_session_data()
-        for v in session_data:
-            print(f"Session message: {v}")
+        for v in reversed(session_data):
+            # For each message, most recent first
             if v[0] == "nowPlaying":
                 if v[1]["listId"]:
                     return v[1]["listId"]


### PR DESCRIPTION
On top of #10, this PR records all the messages from `BIND_URL` into a log, and then uses that log to answer questions like the current playlist ID.

Actually fetching the playlist data still doesn't work, but it should start to work again whenever a replacement for the `watch_queue_ajax` endpoint is found. (Doing that probably requires running the requests from the mobile app through an intercepting proxy, since YouTube's Chromecast support in the Chrome browser no longer supports viewing the playlist, and so the browser inspector can't be used to determine the endpoint to call.)