### PR TITLE
Play and pause support

### DIFF
--- a/casttube/YouTubeSession.py
+++ b/casttube/YouTubeSession.py
@@ -32,6 +32,8 @@ ACTION_REMOVE = "removeVideo"
 ACTION_INSERT = "insertVideo"
 ACTION_ADD = "addVideo"
 ACTION_GET_QUEUE_ITEMS = "action_get_watch_queue_items"
+ACTION_PAUSE = "pause"
+ACTION_PLAY = "play"
 
 GSESSIONID = "gsessionid"
 LOUNGEIDTOKEN = "loungeIdToken"
@@ -118,6 +120,12 @@ class YouTubeSession(object):
     def clear_playlist(self):
         self._queue_action('', ACTION_CLEAR)
 
+    def pause(self):
+        self._queue_action('', ACTION_PAUSE)
+
+    def play(self):
+        self._queue_action('', ACTION_PLAY)
+
     def _parse_length_prefixed_jsons(self, data):
         """
         Takes a string like this:
@@ -145,7 +153,7 @@ class YouTubeSession(object):
 
             # Take the next that many characters
             start_cursor = end_cursor
-            end_cursor += result_length
+            end_cursor += result_length + 1
             json_result = data[start_cursor:end_cursor]
 
             # Parse that as JSON

--- a/casttube/YouTubeSession.py
+++ b/casttube/YouTubeSession.py
@@ -212,8 +212,8 @@ class YouTubeSession(object):
         :return: queue playlist id or None
         """
         session_data = self.get_session_data()
-        for v in session_data:
-            print(f"Session message: {v}")
+        for v in reversed(session_data):
+            # For each message, most recent first
             if v[0] == "nowPlaying":
                 if v[1]["listId"]:
                     return v[1]["listId"]

--- a/casttube/YouTubeSession.py
+++ b/casttube/YouTubeSession.py
@@ -121,9 +121,15 @@ class YouTubeSession(object):
         self._queue_action('', ACTION_CLEAR)
 
     def pause(self):
+        """
+        Pause the playback of the current video.
+        """
         self._queue_action('', ACTION_PAUSE)
 
     def play(self):
+        """
+        Resume playback of a paused video.
+        """
         self._queue_action('', ACTION_PLAY)
 
     def _parse_length_prefixed_jsons(self, data):
@@ -199,20 +205,22 @@ class YouTubeSession(object):
         # numbers?) and log in the event log.
         for item in response_items:
             for message_carrier in item:
-                # Should have a number and then the message
-                if len(message_carrier) > 1:
-                    message = message_carrier[1]
-                    # It has a string name
-                    message_name = message[0]
-                    if len(message) > 1:
-                        # It has a body
-                        message_body = message[1]
-                    else:
-                        # No body
-                        message_body = {}
-                    reformatted_message = (message_name, message_body)
-                    print(f"Observed event: {reformatted_message}")
-                    self._event_log.append(reformatted_message)
+                # Sometimes these are pure integers, sometimes they are pair
+                # lists of integers and messages
+                if isinstance(message_carrier, list):
+                    # Should have a number and then the message
+                    if len(message_carrier) > 1:
+                        message = message_carrier[1]
+                        # It has a string name
+                        message_name = message[0]
+                        if len(message) > 1:
+                            # It has a body
+                            message_body = message[1]
+                        else:
+                            # No body
+                            message_body = {}
+                        reformatted_message = (message_name, message_body)
+                        self._event_log.append(reformatted_message)
 
     def get_queue_playlist_id(self):
         """


### PR DESCRIPTION
This adds play and pause methods that can pause and resume playback, on top of #11, and fixes up the parser to deal with the replies they generate from `BIND_URL`.